### PR TITLE
feat: Implement Institution Management Functionality

### DIFF
--- a/institutionttestrequests.http
+++ b/institutionttestrequests.http
@@ -1,0 +1,54 @@
+### Retrieve institutions by id
+GET http://localhost:8080/app/institutions/1
+Content-Type: application/json
+
+### Add institution
+POST http://localhost:8080/app/institutions
+Content-Type: application/json
+
+{
+  "name": "New Institution",
+  "description": "Description of the new institution"
+}
+
+### Update institution
+PUT http://localhost:8080/app/institutions
+Content-Type: application/json
+
+{
+  "id": 1,
+  "name": "Updated Institution",
+  "description": "Updated description of the institution"
+}
+
+### Delete institurions by id
+DELETE http://localhost:8080/app/institutions/1
+Content-Type: application/json
+
+
+
+### Retrieve institutions by id(invalid id)
+GET http://localhost:8080/app/institutions/111111
+Content-Type: application/json
+
+### Add institution
+POST http://localhost:8080/app/institutions
+Content-Type: application/json
+
+{
+  "name": ""
+}
+
+### Update institution
+PUT http://localhost:8080/app/institutions
+Content-Type: application/json
+
+{
+  "id": 1,
+  "name": "",
+  "description": "Updated description with invalid name"
+}
+
+### Delete institutions by id
+DELETE http://localhost:8080/app/institutions/999999
+Content-Type: application/json

--- a/pom.xml
+++ b/pom.xml
@@ -71,21 +71,24 @@
 			<artifactId>mysql-connector-j</artifactId>
 			<scope>runtime</scope>
 		</dependency>
+
 		<dependency>
 			<groupId>org.mapstruct</groupId>
 			<artifactId>mapstruct</artifactId>
-			<version>1.4.2.Final</version>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-mail</artifactId>
+			<version>1.5.5.Final</version>
 		</dependency>
 		<dependency>
 			<groupId>org.mapstruct</groupId>
 			<artifactId>mapstruct-processor</artifactId>
-			<version>1.4.2.Final</version>
+			<version>1.5.5.Final</version>
 			<scope>provided</scope>
 		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-mail</artifactId>
+		</dependency>
+
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>

--- a/src/main/java/marcykiewicz/mateusz/charitydonationlab/institution/Institution.java
+++ b/src/main/java/marcykiewicz/mateusz/charitydonationlab/institution/Institution.java
@@ -1,14 +1,12 @@
-package marcykiewicz.mateusz.charitydonationlab.category;
+package marcykiewicz.mateusz.charitydonationlab.institution;
 
 import jakarta.persistence.*;
 import lombok.Data;
-import lombok.extern.slf4j.Slf4j;
 
-@Slf4j
-@Data
 @Entity
-@Table(name = "categories")
-public class Category {
+@Data
+@Table(name = "institutions")
+public class Institution {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -17,4 +15,8 @@ public class Category {
 
     @Column(name = "name")
     private String name;
+
+    @Column(name = "description")
+    private String description;
+
 }

--- a/src/main/java/marcykiewicz/mateusz/charitydonationlab/institution/InstitutionController.java
+++ b/src/main/java/marcykiewicz/mateusz/charitydonationlab/institution/InstitutionController.java
@@ -1,0 +1,40 @@
+package marcykiewicz.mateusz.charitydonationlab.institution;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import marcykiewicz.mateusz.charitydonationlab.institution.dto.InstitutionDTO;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/institutions")
+public class InstitutionController {
+
+    private final InstitutionService institutionService;
+
+    @GetMapping("/{id}")
+    private InstitutionDTO findById(@PathVariable Long id) {
+
+        return institutionService.findById(id);
+    }
+
+    @PostMapping
+    private InstitutionDTO save(@RequestBody InstitutionDTO institutionDTO) {
+
+        log.info("{}", institutionDTO);
+        return institutionService.save(institutionDTO);
+    }
+
+    @PutMapping
+    private InstitutionDTO updateInstitution(@RequestBody InstitutionDTO institutionDTO) {
+
+        return institutionService.update(institutionDTO);
+    }
+
+    @DeleteMapping("/{id}")
+    private InstitutionDTO deleteById(@PathVariable Long id) {
+
+        return institutionService.deleteById(id);
+    }
+}

--- a/src/main/java/marcykiewicz/mateusz/charitydonationlab/institution/InstitutionRepository.java
+++ b/src/main/java/marcykiewicz/mateusz/charitydonationlab/institution/InstitutionRepository.java
@@ -1,0 +1,6 @@
+package marcykiewicz.mateusz.charitydonationlab.institution;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface InstitutionRepository extends JpaRepository<Institution, Long> {
+}

--- a/src/main/java/marcykiewicz/mateusz/charitydonationlab/institution/InstitutionService.java
+++ b/src/main/java/marcykiewicz/mateusz/charitydonationlab/institution/InstitutionService.java
@@ -1,0 +1,18 @@
+package marcykiewicz.mateusz.charitydonationlab.institution;
+
+import marcykiewicz.mateusz.charitydonationlab.institution.dto.InstitutionDTO;
+
+import java.util.List;
+
+public interface InstitutionService {
+
+    InstitutionDTO save(InstitutionDTO institutionDTO);
+
+    InstitutionDTO findById(Long id);
+
+    List<InstitutionDTO> findAll();
+
+    InstitutionDTO update(InstitutionDTO institutionDTO);
+
+    InstitutionDTO deleteById(Long id);
+}

--- a/src/main/java/marcykiewicz/mateusz/charitydonationlab/institution/InstitutionServiceImp.java
+++ b/src/main/java/marcykiewicz/mateusz/charitydonationlab/institution/InstitutionServiceImp.java
@@ -1,0 +1,80 @@
+package marcykiewicz.mateusz.charitydonationlab.institution;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import marcykiewicz.mateusz.charitydonationlab.exception.ResourceNotFoundException;
+import marcykiewicz.mateusz.charitydonationlab.institution.dto.InstitutionDTO;
+import marcykiewicz.mateusz.charitydonationlab.institution.dto.InstitutionMapper;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Slf4j
+@RequiredArgsConstructor
+@Transactional
+@Service
+public class InstitutionServiceImp implements InstitutionService {
+
+    @Value("${resourceNotFoundExceptionMessage}")
+    private String resourceNotFoundExceptionMessage;
+
+    private final InstitutionRepository institutionRepository;
+    private final InstitutionMapper institutionMapper;
+
+    @Override
+    public InstitutionDTO save(InstitutionDTO institutionDTO) {
+
+        log.info("DTO before mapping: {}", institutionDTO);
+
+        Institution institution = institutionMapper.toEntity(institutionDTO);
+        log.info("Entity after mapping: {}", institution);
+
+        institutionRepository.save(institution);
+
+        InstitutionDTO savedDTO = institutionMapper.toDTO(institution);
+
+        log.info("DTO after saving: {}", savedDTO);
+        return savedDTO;
+    }
+
+    @Override
+    public InstitutionDTO findById(Long id) {
+
+        Optional<Institution> optionalInstitution = institutionRepository.findById(id);
+
+        return optionalInstitution.map(institutionMapper::toDTO)
+                .orElseThrow(() -> new ResourceNotFoundException(resourceNotFoundExceptionMessage.formatted(id)));
+    }
+
+    @Override
+    public List<InstitutionDTO> findAll() {
+        List<Institution> categories = institutionRepository.findAll();
+
+        return categories.stream().map(institutionMapper::toDTO).toList();
+    }
+
+    @Override
+    public InstitutionDTO update(InstitutionDTO institutionDTO) {
+
+        InstitutionDTO foundInstitutionDTO = findById(institutionDTO.getId());
+
+        Institution institution = institutionMapper.toEntity(institutionDTO);
+
+        Institution updatedinstitution = institutionRepository.save(institution);
+
+        return institutionMapper.toDTO(updatedinstitution);
+    }
+
+
+    @Override
+    public InstitutionDTO deleteById(Long id) {
+
+        InstitutionDTO institutionDTO = findById(id);
+
+        institutionRepository.deleteById(id);
+        return institutionDTO;
+    }
+}

--- a/src/main/java/marcykiewicz/mateusz/charitydonationlab/institution/dto/InstitutionDTO.java
+++ b/src/main/java/marcykiewicz/mateusz/charitydonationlab/institution/dto/InstitutionDTO.java
@@ -1,0 +1,13 @@
+package marcykiewicz.mateusz.charitydonationlab.institution.dto;
+
+import lombok.Data;
+
+@Data
+public class InstitutionDTO {
+
+    private Long id;
+
+    private String name;
+
+    private String description;
+}

--- a/src/main/java/marcykiewicz/mateusz/charitydonationlab/institution/dto/InstitutionMapper.java
+++ b/src/main/java/marcykiewicz/mateusz/charitydonationlab/institution/dto/InstitutionMapper.java
@@ -1,0 +1,15 @@
+package marcykiewicz.mateusz.charitydonationlab.institution.dto;
+
+import marcykiewicz.mateusz.charitydonationlab.institution.Institution;
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+@Mapper(componentModel = "spring")
+public interface InstitutionMapper {
+
+    InstitutionMapper INSTANCE = Mappers.getMapper(InstitutionMapper.class);
+
+    Institution toEntity(InstitutionDTO institutionDTO);
+
+    InstitutionDTO toDTO(Institution institution);
+}


### PR DESCRIPTION
- Add Institution.java entity class with JPA annotations for table mapping.
- Create InstitutionDTO.java for data transfer objects.
- Develop InstitutionMapper.java for mapping between Institution and InstitutionDTO using MapStruct.
- Implement InstitutionService.java interface defining CRUD operations for institutions.
- Provide InstitutionServiceImp.java service implementation, including transactional management and exception handling.
- Establish InstitutionController.java REST controller to expose institution endpoints and integrate with the service layer.
- Configure InstitutionRepository.java for JPA repository functionality.
- Update pom.xml to include MapStruct dependencies for annotation processing.
- Ensure Institution entity uses Lombok @Data annotation for boilerplate code reduction.
- Add logging to InstitutionServiceImp.java for debugging and tracking entity state transitions.

These changes introduce the core functionality for managing institutions within the charity donation application, including saving, retrieving, updating, and deleting institutions.